### PR TITLE
Add kubectl-view-webhook Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Now, `awesome-kubectl-plugins` is not just a list of awesome kubectl plugins (wi
 | 97  | [kubectl-cilium](https://github.com/bmcustodio/kubectl-cilium)                     | A kubectl plugin for interacting with Cilium.                                                    | Networking
 | 98  | [kubectl-carbonetes-scan](https://github.com/carbonetes/kubectl-carbonetes-scan)   | Integrates container analysis directly into your cluster. | Container Security |
 | 99  | [kubectl-cyclonus](https://github.com/mattfenwick/kubectl-cyclonus)                     | Analyze, explain, and probe network policies.                                                    | Networking |
+| 100  | [kubectl-view-webhook](https://github.com/Trendyol/kubectl-view-webhook)           | Visualize your webhook configurations                                                                | Visibility |
 
 ### Collection of kubectl plugins
 

--- a/plugins/view-webhook.yaml
+++ b/plugins/view-webhook.yaml
@@ -1,0 +1,29 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: view-webhook
+spec:
+  version: {{ .TagName }}
+  homepage: https://github.com/Trendyol/kubectl-view-webhook
+  shortDescription: Visualize your webhook configurations
+  description: |
+    Visualize critical parts of the admission webhook configuration resource
+  platforms:
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+      {{ addURIAndSha "https://github.com/Trendyol/kubectl-view-webhook/releases/download/{{ .TagName }}/kubectl-view-webhook_{{ .TagName }}_darwin_amd64.tar.gz" .TagName | indent 6}}
+      bin: kubectl-view-webhook
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      {{ addURIAndSha "https://github.com/Trendyol/kubectl-view-webhook/releases/download/{{ .TagName }}/kubectl-view-webhook_{{ .TagName }}_linux_amd64.tar.gz" .TagName | indent 6}}
+      bin: kubectl-view-webhook
+    - selector:
+        matchLabels:
+          os: linux
+          arch: 386
+      {{ addURIAndSha "https://github.com/Trendyol/kubectl-view-webhook/releases/download/{{ .TagName }}/kubectl-view-webhook_{{ .TagName }}_linux_386.tar.gz" .TagName | indent 6}}
+      bin: kubectl-view-webhook


### PR DESCRIPTION
This PR simply adds [kubectl-view-webhook](https://github.com/Trendyol/kubectl-view-webhook) plugin.

Signed-off-by: Dentrax <furkan.turkal@hotmail.com>